### PR TITLE
Update accounts_piecash.py

### DIFF
--- a/ixbrl_reporter/accounts_piecash.py
+++ b/ixbrl_reporter/accounts_piecash.py
@@ -58,7 +58,7 @@ class Accounts:
                 splits.append(
                     {
                         "date": dt,
-                        "amount": float(spl.value),
+                        "amount": float(spl.quantity),
                         "description": tx.description
                     }
                 )


### PR DESCRIPTION
when summing the splits in an account you want the value in the currency of the account, not the currency of the split