### PR TITLE
Feature/suppress zero

### DIFF
--- a/detail/metadata-corptax.yaml
+++ b/detail/metadata-corptax.yaml
@@ -184,3 +184,8 @@ tax:
     start: '2020-04-01'
     end: '2020-12-31'
     year: '2020'
+
+  rnd-claim-notification-submitted: false
+
+  rnd-additional-notification-submitted: false
+

--- a/docs/config.md
+++ b/docs/config.md
@@ -209,6 +209,58 @@ adding the `depreciation` expense will make the expense larger.
 So, the computation can be made by taking a 'reversed' depreciation expense
 and adding it to management expenses.
 
+### Zero clamping
+
+The `zero-if` attribute can be used to clamp a computed value to zero
+when it meets a condition:
+
+```
+zero-if: less-than-zero
+```
+
+or:
+
+```
+zero-if: greater-than-zero
+```
+
+With `less-than-zero`, any negative result is replaced with zero.
+With `greater-than-zero`, any positive result is replaced with zero.
+This can be applied to `line`, `group` and `sum` computations.
+
+### Suppressing zero lines
+
+The `suppress-if-zero` attribute removes a line from the output when its
+value is zero across all periods.  This is useful for expense categories
+that may not apply every year:
+
+```
+- id: software-expenses
+  kind: line
+  description: Software
+  accounts:
+  - Expenses:VAT Purchases:Software
+  period: in-year
+  suppress-if-zero: true
+```
+
+If Software is 0.00 in both the current and prior year, the line will not
+appear in the report.  If it has a value in any period, it will be shown
+for all periods.
+
+When `suppress-if-zero` is set on individual lines within a `group`, those
+lines are filtered from the breakdown.  If all lines in a group are
+suppressed, the group collapses to a single total line rather than showing
+an empty breakdown.
+
+`suppress-if-zero` can also be set on a `group` or `sum` computation
+itself, which suppresses the entire section when the total is zero
+across all periods.
+
+`zero-if` and `suppress-if-zero` can be combined: `zero-if` is applied
+first during computation, and `suppress-if-zero` then checks the
+(possibly clamped) result.
+
 ### iXBRL
 
 Regarding iXBRL output, the taxonomy configuration file is used to map

--- a/ixbrl_reporter/computation.py
+++ b/ixbrl_reporter/computation.py
@@ -28,14 +28,20 @@ CMP_LESS_EQUAL = 2
 CMP_GREATER = 3
 CMP_GREATER_EQUAL = 4
 
+ZERO_IF_LESS = 1
+ZERO_IF_GREATER = 2
+
 class Metadata:
-    def __init__(self, id, description, context, segments, period, note):
+    def __init__(self, id, description, context, segments, period, note,
+                 suppress_zero=False, zero_if=None):
         self.id = id
         self.description = description
         self.context = context
         self.segments = segments
         self.period = period
         self.note = note
+        self.suppress_zero = suppress_zero
+        self.zero_if = zero_if
         
     @staticmethod
     def load(cfg, comps, context, data, gcfg):
@@ -73,7 +79,16 @@ class Metadata:
 
         if note: note = str(note)
 
-        return Metadata(id, description, context, segs, pid, note)
+        suppress_zero = cfg.get_bool("suppress-if-zero", False)
+
+        zero_if_spec = cfg.get("zero-if", mandatory=False)
+        zero_if = {
+            "less-than-zero": ZERO_IF_LESS,
+            "greater-than-zero": ZERO_IF_GREATER,
+        }.get(zero_if_spec)
+
+        return Metadata(id, description, context, segs, pid, note,
+                        suppress_zero, zero_if)
 
     def get_context(self, start, end):
 
@@ -186,6 +201,11 @@ class Line(Computable):
 
         if self.reverse: total *= -1
 
+        if self.metadata.zero_if == ZERO_IF_LESS and total < 0:
+            total = 0
+        elif self.metadata.zero_if == ZERO_IF_GREATER and total > 0:
+            total = 0
+
         if len(self.metadata.segments) != 0:
             context = context.with_segments(self.metadata.segments)
 
@@ -280,6 +300,11 @@ class Group(Computable):
         total = 0
         for input in self.inputs:
             total += input.compute(accounts, start, end, result)
+
+        if self.metadata.zero_if == ZERO_IF_LESS and total < 0:
+            total = 0
+        elif self.metadata.zero_if == ZERO_IF_GREATER and total > 0:
+            total = 0
 
         result.set(
             self.metadata.id,
@@ -555,6 +580,11 @@ class Sum(Computable):
 
         for v in self.steps:
             total += v.compute(accounts, start, end, result)
+
+        if self.metadata.zero_if == ZERO_IF_LESS and total < 0:
+            total = 0
+        elif self.metadata.zero_if == ZERO_IF_GREATER and total > 0:
+            total = 0
 
         context = self.metadata.get_context(start, end)
 

--- a/ixbrl_reporter/simple_sheet.py
+++ b/ixbrl_reporter/simple_sheet.py
@@ -12,6 +12,13 @@ class WorksheetSection:
     def __init__(self, id):
         self.id = id
 
+def is_all_zero(computation, results):
+    for period, result in results:
+        value = computation.get_output(result).value
+        if abs(value.value) > 0:
+            return False
+    return True
+
 class SimpleWorksheet(Worksheet):
 
     def __init__(self, comps, periods, data):
@@ -40,6 +47,10 @@ class SimpleWorksheet(Worksheet):
 
     def get_single_line_ix(self, computation, results):
 
+        if computation.metadata.suppress_zero:
+            if is_all_zero(computation, results):
+                return None
+
         cells = []
 
         for period, result in results:
@@ -63,8 +74,18 @@ class SimpleWorksheet(Worksheet):
 
     def get_breakdown_ix(self, computation, results):
 
+        # If the whole group is suppress-zero and all zero, skip entirely
+        if computation.metadata.suppress_zero:
+            if is_all_zero(computation, results):
+                return None
+
         item_ixs = []
         for item in computation.inputs:
+
+            # Filter out zero children that have suppress-zero
+            if item.metadata.suppress_zero:
+                if is_all_zero(item, results):
+                    continue
 
             note = None
             if item.metadata.note:
@@ -98,6 +119,13 @@ class SimpleWorksheet(Worksheet):
                 note = self.data.get_note(computation.metadata.note)
             except:
                 pass
+
+        # If all children were suppressed, render as a single line
+        # instead of a group with just a total
+        if len(item_ixs) == 0:
+            ix = TotalIndex(computation.metadata, Row(cells), notes=note)
+            ix = Index(computation.metadata, [ix])
+            return ix
 
         ix = TotalIndex(computation.metadata, Row(cells))
         item_ixs.append(ix)
@@ -140,12 +168,12 @@ class SimpleWorksheet(Worksheet):
             computation = computations[cid]
 
             if isinstance(computation, Group):
-
                 ix = self.get_breakdown_ix(computation, results)
-                ixs.append(ix)
-
             else:
-                ixs.append(self.get_single_line_ix(computation, results))
+                ix = self.get_single_line_ix(computation, results)
+
+            if ix is not None:
+                ixs.append(ix)
 
         tbl = Table(columns, ixs)
 

--- a/tests/unit/test_computation.py
+++ b/tests/unit/test_computation.py
@@ -12,7 +12,8 @@ from ixbrl_reporter.computation import (
     get_computation, create_uuid, ResultSet,
     IN_YEAR, AT_START, AT_END,
     ROUND_DOWN, ROUND_UP, ROUND_NEAREST,
-    CMP_LESS, CMP_LESS_EQUAL, CMP_GREATER, CMP_GREATER_EQUAL
+    CMP_LESS, CMP_LESS_EQUAL, CMP_GREATER, CMP_GREATER_EQUAL,
+    ZERO_IF_LESS, ZERO_IF_GREATER
 )
 
 
@@ -79,6 +80,11 @@ class TestConstants:
         assert CMP_LESS_EQUAL == 2
         assert CMP_GREATER == 3
         assert CMP_GREATER_EQUAL == 4
+
+    def test_zero_if_constants(self):
+        """Test zero-if type constants"""
+        assert ZERO_IF_LESS == 1
+        assert ZERO_IF_GREATER == 2
 
 
 class TestResultSet:
@@ -306,7 +312,109 @@ class TestMetadata:
         metadata = Metadata.load(mock_cfg, {}, self.mock_context, None, self.mock_gcfg)
         
         assert metadata.note == "12345"
-    
+
+    def test_metadata_init_suppress_zero_default(self):
+        """Metadata should default suppress_zero to False"""
+        metadata = Metadata("id", "desc", None, [], AT_END, None)
+        assert metadata.suppress_zero is False
+        assert metadata.zero_if is None
+
+    def test_metadata_init_suppress_zero(self):
+        """Metadata should store suppress_zero and zero_if"""
+        metadata = Metadata("id", "desc", None, [], AT_END, None,
+                            suppress_zero=True, zero_if=ZERO_IF_LESS)
+        assert metadata.suppress_zero is True
+        assert metadata.zero_if == ZERO_IF_LESS
+
+    def test_metadata_load_suppress_if_zero(self):
+        """Metadata.load should parse suppress-if-zero from config"""
+        mock_cfg = Mock()
+
+        def mock_get(key, deflt=None, mandatory=True):
+            values = {
+                "id": "test-id",
+                "description": "Test",
+                "period": "at-end",
+                "segments": [],
+                "note": None,
+                "zero-if": None,
+            }
+            return values.get(key, deflt)
+
+        mock_cfg.get.side_effect = mock_get
+        mock_cfg.get_bool.return_value = True
+
+        metadata = Metadata.load(mock_cfg, {}, self.mock_context, None, self.mock_gcfg)
+
+        mock_cfg.get_bool.assert_called_once_with("suppress-if-zero", False)
+        assert metadata.suppress_zero is True
+
+    def test_metadata_load_zero_if_less_than_zero(self):
+        """Metadata.load should parse zero-if: less-than-zero"""
+        mock_cfg = Mock()
+
+        def mock_get(key, deflt=None, mandatory=True):
+            values = {
+                "id": "test-id",
+                "description": "Test",
+                "period": "at-end",
+                "segments": [],
+                "note": None,
+                "zero-if": "less-than-zero",
+            }
+            return values.get(key, deflt)
+
+        mock_cfg.get.side_effect = mock_get
+        mock_cfg.get_bool.return_value = False
+
+        metadata = Metadata.load(mock_cfg, {}, self.mock_context, None, self.mock_gcfg)
+
+        assert metadata.zero_if == ZERO_IF_LESS
+
+    def test_metadata_load_zero_if_greater_than_zero(self):
+        """Metadata.load should parse zero-if: greater-than-zero"""
+        mock_cfg = Mock()
+
+        def mock_get(key, deflt=None, mandatory=True):
+            values = {
+                "id": "test-id",
+                "description": "Test",
+                "period": "at-end",
+                "segments": [],
+                "note": None,
+                "zero-if": "greater-than-zero",
+            }
+            return values.get(key, deflt)
+
+        mock_cfg.get.side_effect = mock_get
+        mock_cfg.get_bool.return_value = False
+
+        metadata = Metadata.load(mock_cfg, {}, self.mock_context, None, self.mock_gcfg)
+
+        assert metadata.zero_if == ZERO_IF_GREATER
+
+    def test_metadata_load_zero_if_none(self):
+        """Metadata.load should set zero_if to None when not specified"""
+        mock_cfg = Mock()
+
+        def mock_get(key, deflt=None, mandatory=True):
+            values = {
+                "id": "test-id",
+                "description": "Test",
+                "period": "at-end",
+                "segments": [],
+                "note": None,
+                "zero-if": None,
+            }
+            return values.get(key, deflt)
+
+        mock_cfg.get.side_effect = mock_get
+        mock_cfg.get_bool.return_value = False
+
+        metadata = Metadata.load(mock_cfg, {}, self.mock_context, None, self.mock_gcfg)
+
+        assert metadata.zero_if is None
+
     def test_metadata_get_context_at_start(self):
         """get_context should handle AT_START period correctly"""
         metadata = Metadata("id", "desc", self.mock_context, [], AT_START, None)
@@ -720,6 +828,106 @@ class TestLine:
         mock_total_result.assert_called_once_with(line, mock_datum, items=[])
         assert output == mock_total_instance
 
+    def test_line_compute_zero_if_less_clamps_negative(self):
+        """Line.compute should clamp negative total to zero when zero_if=ZERO_IF_LESS"""
+        self.mock_metadata.period = IN_YEAR
+        self.mock_metadata.zero_if = ZERO_IF_LESS
+
+        mock_context = Mock()
+        mock_session = Mock()
+        mock_account = Mock()
+        mock_result = Mock()
+
+        self.mock_metadata.context.with_period.return_value = mock_context
+        mock_session.get_account.return_value = mock_account
+        mock_session.get_splits.return_value = [{"amount": -100.0}]
+        mock_session.is_debit.return_value = False
+
+        line = Line(self.mock_metadata, ["Expenses:Rent"], reverse=False)
+        result = line.compute(mock_session, date(2023, 1, 1), date(2023, 12, 31), mock_result)
+
+        assert result == 0
+
+    def test_line_compute_zero_if_less_keeps_positive(self):
+        """Line.compute should keep positive total when zero_if=ZERO_IF_LESS"""
+        self.mock_metadata.period = IN_YEAR
+        self.mock_metadata.zero_if = ZERO_IF_LESS
+
+        mock_context = Mock()
+        mock_session = Mock()
+        mock_account = Mock()
+        mock_result = Mock()
+
+        self.mock_metadata.context.with_period.return_value = mock_context
+        mock_session.get_account.return_value = mock_account
+        mock_session.get_splits.return_value = [{"amount": 100.0}]
+        mock_session.is_debit.return_value = False
+
+        line = Line(self.mock_metadata, ["Revenue:Sales"], reverse=False)
+        result = line.compute(mock_session, date(2023, 1, 1), date(2023, 12, 31), mock_result)
+
+        assert result == 100.0
+
+    def test_line_compute_zero_if_greater_clamps_positive(self):
+        """Line.compute should clamp positive total to zero when zero_if=ZERO_IF_GREATER"""
+        self.mock_metadata.period = IN_YEAR
+        self.mock_metadata.zero_if = ZERO_IF_GREATER
+
+        mock_context = Mock()
+        mock_session = Mock()
+        mock_account = Mock()
+        mock_result = Mock()
+
+        self.mock_metadata.context.with_period.return_value = mock_context
+        mock_session.get_account.return_value = mock_account
+        mock_session.get_splits.return_value = [{"amount": 100.0}]
+        mock_session.is_debit.return_value = False
+
+        line = Line(self.mock_metadata, ["Revenue:Sales"], reverse=False)
+        result = line.compute(mock_session, date(2023, 1, 1), date(2023, 12, 31), mock_result)
+
+        assert result == 0
+
+    def test_line_compute_zero_if_greater_keeps_negative(self):
+        """Line.compute should keep negative total when zero_if=ZERO_IF_GREATER"""
+        self.mock_metadata.period = IN_YEAR
+        self.mock_metadata.zero_if = ZERO_IF_GREATER
+
+        mock_context = Mock()
+        mock_session = Mock()
+        mock_account = Mock()
+        mock_result = Mock()
+
+        self.mock_metadata.context.with_period.return_value = mock_context
+        mock_session.get_account.return_value = mock_account
+        mock_session.get_splits.return_value = [{"amount": -50.0}]
+        mock_session.is_debit.return_value = False
+
+        line = Line(self.mock_metadata, ["Expenses:Rent"], reverse=False)
+        result = line.compute(mock_session, date(2023, 1, 1), date(2023, 12, 31), mock_result)
+
+        assert result == -50.0
+
+    def test_line_compute_zero_if_none_no_clamping(self):
+        """Line.compute should not clamp when zero_if is None"""
+        self.mock_metadata.period = IN_YEAR
+        self.mock_metadata.zero_if = None
+
+        mock_context = Mock()
+        mock_session = Mock()
+        mock_account = Mock()
+        mock_result = Mock()
+
+        self.mock_metadata.context.with_period.return_value = mock_context
+        mock_session.get_account.return_value = mock_account
+        mock_session.get_splits.return_value = [{"amount": -100.0}]
+        mock_session.is_debit.return_value = False
+
+        line = Line(self.mock_metadata, ["Expenses:Rent"], reverse=False)
+        result = line.compute(mock_session, date(2023, 1, 1), date(2023, 12, 31), mock_result)
+
+        assert result == -100.0
+
 
 class TestConstant:
     """Test Constant computation class"""
@@ -1010,6 +1218,52 @@ class TestGroup:
         )
         assert output == mock_breakdown_instance
 
+    def test_group_compute_zero_if_less_clamps_negative(self):
+        """Group.compute should clamp negative total to zero when zero_if=ZERO_IF_LESS"""
+        mock_input1 = Mock()
+        mock_input2 = Mock()
+        mock_input1.compute.return_value = -100.0
+        mock_input2.compute.return_value = -50.0
+
+        self.mock_metadata.zero_if = ZERO_IF_LESS
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        group = Group(self.mock_metadata, [mock_input1, mock_input2])
+        result = group.compute("accounts", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == 0
+
+    def test_group_compute_zero_if_greater_clamps_positive(self):
+        """Group.compute should clamp positive total to zero when zero_if=ZERO_IF_GREATER"""
+        mock_input1 = Mock()
+        mock_input2 = Mock()
+        mock_input1.compute.return_value = 100.0
+        mock_input2.compute.return_value = 50.0
+
+        self.mock_metadata.zero_if = ZERO_IF_GREATER
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        group = Group(self.mock_metadata, [mock_input1, mock_input2])
+        result = group.compute("accounts", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == 0
+
+    def test_group_compute_zero_if_none_no_clamping(self):
+        """Group.compute should not clamp when zero_if is None"""
+        mock_input1 = Mock()
+        mock_input1.compute.return_value = -100.0
+
+        self.mock_metadata.zero_if = None
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        group = Group(self.mock_metadata, [mock_input1])
+        result = group.compute("accounts", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == -100.0
+
 
 class TestSum:
     """Test Sum computation class"""
@@ -1106,6 +1360,60 @@ class TestSum:
             sum_comp, mock_datum, items=[mock_input1, mock_input2]
         )
         assert output == mock_total_instance
+
+    def test_sum_compute_zero_if_less_clamps_negative(self):
+        """Sum.compute should clamp negative total to zero when zero_if=ZERO_IF_LESS"""
+        mock_input1 = Mock()
+        mock_input2 = Mock()
+        mock_input1.compute.return_value = -100.0
+        mock_input2.compute.return_value = -50.0
+
+        self.mock_metadata.zero_if = ZERO_IF_LESS
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        sum_comp = Sum(self.mock_metadata)
+        sum_comp.add(mock_input1)
+        sum_comp.add(mock_input2)
+
+        result = sum_comp.compute("session", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == 0
+
+    def test_sum_compute_zero_if_greater_clamps_positive(self):
+        """Sum.compute should clamp positive total to zero when zero_if=ZERO_IF_GREATER"""
+        mock_input1 = Mock()
+        mock_input2 = Mock()
+        mock_input1.compute.return_value = 100.0
+        mock_input2.compute.return_value = 50.0
+
+        self.mock_metadata.zero_if = ZERO_IF_GREATER
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        sum_comp = Sum(self.mock_metadata)
+        sum_comp.add(mock_input1)
+        sum_comp.add(mock_input2)
+
+        result = sum_comp.compute("session", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == 0
+
+    def test_sum_compute_zero_if_none_no_clamping(self):
+        """Sum.compute should not clamp when zero_if is None"""
+        mock_input1 = Mock()
+        mock_input1.compute.return_value = -100.0
+
+        self.mock_metadata.zero_if = None
+        mock_context = Mock()
+        self.mock_metadata.get_context.return_value = mock_context
+
+        sum_comp = Sum(self.mock_metadata)
+        sum_comp.add(mock_input1)
+
+        result = sum_comp.compute("session", date(2023, 1, 1), date(2023, 12, 31), Mock())
+
+        assert result == -100.0
 
 
 class TestAbsOperation:

--- a/tests/unit/test_simple_sheet.py
+++ b/tests/unit/test_simple_sheet.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for ixbrl_reporter.simple_sheet module
+
+Tests for suppress-if-zero and is_all_zero functionality.
+"""
+import pytest
+from unittest.mock import Mock
+from datetime import date
+
+from ixbrl_reporter.simple_sheet import SimpleWorksheet, is_all_zero
+from ixbrl_reporter.computation import Group
+from ixbrl_reporter.table import Index, TotalIndex, Row
+
+
+def make_computation(value_per_period, suppress_zero=False):
+    """Create a mock computation that returns the given value for each period.
+
+    value_per_period: a single value (used for all periods) or a list.
+    Values cycle so the mock can be called multiple times (e.g. by
+    is_all_zero and then again by cell creation).
+    """
+    if not isinstance(value_per_period, list):
+        value_per_period = [value_per_period]
+
+    comp = Mock()
+    comp.metadata.suppress_zero = suppress_zero
+    comp.metadata.note = None
+
+    call_count = [0]
+
+    def make_output(result):
+        out = Mock()
+        datum = Mock()
+        datum.value = value_per_period[call_count[0] % len(value_per_period)]
+        call_count[0] += 1
+        out.value = datum
+        return out
+
+    comp.get_output.side_effect = make_output
+    return comp
+
+
+def make_results(n_periods=2):
+    """Create a list of (period, result) tuples."""
+    return [(Mock(), Mock()) for _ in range(n_periods)]
+
+
+class TestIsAllZero:
+    """Test the is_all_zero helper function"""
+
+    def test_all_zero_single_period(self):
+        comp = make_computation([0])
+        results = make_results(1)
+        assert is_all_zero(comp, results) is True
+
+    def test_all_zero_multiple_periods(self):
+        comp = make_computation([0, 0])
+        results = make_results(2)
+        assert is_all_zero(comp, results) is True
+
+    def test_not_all_zero_one_nonzero(self):
+        comp = make_computation([0, 100.0])
+        results = make_results(2)
+        assert is_all_zero(comp, results) is False
+
+    def test_not_all_zero_all_nonzero(self):
+        comp = make_computation([50.0, 100.0])
+        results = make_results(2)
+        assert is_all_zero(comp, results) is False
+
+    def test_negative_value_is_nonzero(self):
+        comp = make_computation([0, -1.0])
+        results = make_results(2)
+        assert is_all_zero(comp, results) is False
+
+
+class TestSingleLineSuppress:
+    """Test suppress-if-zero for single line computations"""
+
+    def setup_method(self):
+        self.ws = SimpleWorksheet([], [], Mock())
+
+    def test_suppress_zero_returns_none(self):
+        """A zero line with suppress-if-zero should be suppressed"""
+        comp = make_computation([0, 0], suppress_zero=True)
+        results = make_results(2)
+
+        ix = self.ws.get_single_line_ix(comp, results)
+        assert ix is None
+
+    def test_suppress_zero_nonzero_keeps_line(self):
+        """A non-zero line with suppress-if-zero should not be suppressed"""
+        comp = make_computation([0, 100.0], suppress_zero=True)
+        results = make_results(2)
+
+        ix = self.ws.get_single_line_ix(comp, results)
+        assert ix is not None
+        assert isinstance(ix, Index)
+
+    def test_no_suppress_zero_keeps_line(self):
+        """A zero line without suppress-if-zero should not be suppressed"""
+        comp = make_computation([0, 0], suppress_zero=False)
+        results = make_results(2)
+
+        ix = self.ws.get_single_line_ix(comp, results)
+        assert ix is not None
+
+
+class TestBreakdownSuppress:
+    """Test suppress-if-zero for group breakdown computations"""
+
+    def setup_method(self):
+        self.ws = SimpleWorksheet([], [], Mock())
+
+    def _make_group(self, inputs, group_value_per_period,
+                    suppress_zero=False):
+        """Create a mock Group computation with inputs."""
+        group = Mock()
+        group.metadata.suppress_zero = suppress_zero
+        group.metadata.note = None
+        group.inputs = inputs
+
+        if not isinstance(group_value_per_period, list):
+            group_value_per_period = [group_value_per_period]
+
+        call_count = [0]
+
+        def make_output(result):
+            out = Mock()
+            datum = Mock()
+            datum.value = group_value_per_period[
+                call_count[0] % len(group_value_per_period)
+            ]
+            call_count[0] += 1
+            out.value = datum
+            return out
+
+        group.get_output.side_effect = make_output
+        return group
+
+    def test_suppress_zero_group_all_zero(self):
+        """A group with suppress-if-zero where total is zero should return None"""
+        child = make_computation([10, 20])
+        group = self._make_group([child], [0, 0], suppress_zero=True)
+
+        results = make_results(2)
+        ix = self.ws.get_breakdown_ix(group, results)
+        assert ix is None
+
+    def test_suppress_zero_group_nonzero_keeps(self):
+        """A group with suppress-if-zero where total is non-zero should remain"""
+        child = make_computation([10, 20])
+        group = self._make_group([child], [10, 20], suppress_zero=True)
+
+        results = make_results(2)
+        ix = self.ws.get_breakdown_ix(group, results)
+        assert ix is not None
+
+    def test_suppress_zero_child_filtered(self):
+        """A zero child with suppress-if-zero should be filtered from group"""
+        child_kept = make_computation([100, 200], suppress_zero=False)
+        child_suppressed = make_computation([0, 0], suppress_zero=True)
+
+        group = self._make_group(
+            [child_kept, child_suppressed], [100, 200]
+        )
+
+        results = make_results(2)
+        ix = self.ws.get_breakdown_ix(group, results)
+
+        # Should be a group index with heading + 1 child + total = 3 items
+        # The outer Index contains child indices
+        assert isinstance(ix, Index)
+        # child list: 1 kept child + 1 TotalIndex
+        children = ix.child
+        assert len(children) == 2
+        assert isinstance(children[0], Index)
+        assert isinstance(children[1], TotalIndex)
+
+    def test_suppress_zero_child_nonzero_kept(self):
+        """A non-zero child with suppress-if-zero should remain in group"""
+        child = make_computation([0, 100.0], suppress_zero=True)
+
+        group = self._make_group([child], [0, 100.0])
+
+        results = make_results(2)
+        ix = self.ws.get_breakdown_ix(group, results)
+
+        children = ix.child
+        # 1 child + 1 total
+        assert len(children) == 2
+
+    def test_all_children_suppressed_renders_as_single_line(self):
+        """When all children are suppressed, group renders as a single line"""
+        child1 = make_computation([0, 0], suppress_zero=True)
+        child2 = make_computation([0, 0], suppress_zero=True)
+
+        group = self._make_group([child1, child2], [0, 0])
+
+        results = make_results(2)
+        ix = self.ws.get_breakdown_ix(group, results)
+
+        # Should look like a single line: Index wrapping a TotalIndex
+        assert isinstance(ix, Index)
+        assert len(ix.child) == 1
+        assert isinstance(ix.child[0], TotalIndex)
+
+
+class TestGetTableSuppress:
+    """Test suppress-if-zero integration in get_table"""
+
+    def test_suppressed_lines_excluded_from_table(self):
+        """Suppressed lines should not appear in the table"""
+        mock_data = Mock()
+        mock_data.get_config.return_value = "£"
+
+        period = Mock()
+        period.name = "2020"
+        mock_data.get_periods.return_value = [period]
+
+        # Two computations: one kept, one suppressed
+        comp_kept = make_computation([100.0], suppress_zero=False)
+        comp_kept.metadata.id = "kept"
+
+        comp_suppressed = make_computation([0], suppress_zero=True)
+        comp_suppressed.metadata.id = "suppressed"
+
+        mock_data.get_computation.side_effect = lambda id: {
+            "kept": comp_kept,
+            "suppressed": comp_suppressed,
+        }[id]
+
+        result_set = Mock()
+        mock_data.perform_computations.return_value = result_set
+
+        ws_elts = [Mock(), Mock()]
+        ws_elts[0].id = "kept"
+        ws_elts[1].id = "suppressed"
+
+        ws = SimpleWorksheet(ws_elts, [period], mock_data)
+        table = ws.get_table(Mock())
+
+        # Only 1 row should remain (the kept one)
+        assert len(table.ixs) == 1


### PR DESCRIPTION
 - Added a setting suppress-zero which if applied to a line, AND  all periods have a zero, value, then removes the line from the report.  This will also mean iXBRL tags will not be emitted for the value at that point in the report (it could end up being reported and tagged elsewhere).
- Added a setting `zero-if: less-than-zero` which, if set AND the value is less than zero, treats the value as if it were zero.  In the report, zero may be shown.  If tagged, the tags will show zero. Further, if `suppress-zero` is set, the value may not be shown at all (and no tag output).
- A setting `zero-if: greater-than-zero` which is the reverse condition on the less-than-zero case.
